### PR TITLE
Force repo to "Clone" for Deploy to Bluemix.

### DIFF
--- a/.bluemix/toolchain.yml
+++ b/.bluemix/toolchain.yml
@@ -1,0 +1,10 @@
+version: '2'
+services:
+  sample-repo:
+    service_id: githubpublic
+    parameters:
+      repo_name: '{{toolchain.name}}'
+      repo_url: 'https://github.com/scottdangelo/watson-conversation-slots-intro'
+      type: clone
+      has_issues: true
+      enable_traceability: true


### PR DESCRIPTION
For reasons not yet understood, the `Deploy to Bluemix` button
now uses Bluemix hosted Git repository, and for this journey
the default Repository Type is "Existing". This fix changes that
to "Clone" as is seen in other repositories that do not contain
the issue.

Closes: #45